### PR TITLE
Remove Bourbon imports from App component

### DIFF
--- a/template/src/App.vue
+++ b/template/src/App.vue
@@ -22,6 +22,4 @@ export default {
 </script>
 
 <style lang="scss">
-  @import 'bourbon';
-  @import 'neat';
 </style>


### PR DESCRIPTION
They cause errors when you first run the application as they have been removed from the project.